### PR TITLE
Instead of splitting the SSE stream, use a consolidated stream with oob swap for some events

### DIFF
--- a/routers/chat.py
+++ b/routers/chat.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from datetime import datetime
 from typing import AsyncGenerator, Optional, Union
 from fastapi.templating import Jinja2Templates
@@ -113,16 +112,19 @@ async def stream_response(
                         "messageCreated",
                         templates.get_template("components/assistant-step.html").render(
                             step_type="assistantMessage",
-                            stream_name=f"textDelta{step_id}"
+                            step_id=step_id
                         )
                     )
 
                 if isinstance(event, ThreadMessageDelta) and event.data.delta.content:
                     content: MessageContentDelta = event.data.delta.content[0]
                     if isinstance(content, TextDeltaBlock) and content.text and content.text.value:
+                        step_id = event.data.id
+                        text_value = content.text.value
+                        sse_data = f'<span hx-swap-oob="beforeend:#step-{step_id}">{text_value}</span>'
                         yield sse_format(
-                            f"textDelta{step_id}",
-                            content.text.value
+                            "textDelta",
+                            sse_data
                         )
 
                 if isinstance(event, ThreadRunStepCreated) and event.data.type == "tool_calls":

--- a/templates/components/assistant-run.html
+++ b/templates/components/assistant-run.html
@@ -2,7 +2,7 @@
 <div class="assistant-run" hx-swap="beforeend" 
      hx-ext="sse"     
      sse-connect="/assistants/{{ assistant_id }}/messages/{{ thread_id }}/receive" 
-     sse-swap="messageCreated,toolCallCreated,toolOutput,imageOutput,fileOutput" 
+     sse-swap="messageCreated,toolCallCreated,toolOutput,imageOutput,fileOutput,textDelta" 
      sse-close="endStream"
      data-assistant-id="{{ assistant_id }}"
      data-thread-id="{{ thread_id }}">

--- a/templates/components/assistant-step.html
+++ b/templates/components/assistant-step.html
@@ -1,2 +1,2 @@
 <!-- assistant-step.html -->
-<div class="{{ step_type }}" sse-swap="{{ stream_name }}"></div>
+<div class="{{ step_type }}" id="step-{{ step_id }}"></div>


### PR DESCRIPTION
Fixes #26

In the previous implementation, we had an SSE event listener on the assistant-run div that listed for a new assistant-step and mounted an assistant-step div when it received that event. The assistant-step, in turn, had its own SSE listener for text delta events. But this strategy for splitting the event stream resulted in a race condition where some text deltas arrived before the assistant-step got fully mounted, and as a result, we missed the first few text deltas.

The core problem was the use of multiple SSE listeners, one of which was not mounted until mid-stream. I knew that if I could handle all the events from a single listener on the assistant-run div, then the listener could mount the assistant-step div and text deltas synchronously without missing anything. But I thought this was impossible, because HTMX doesn't have a swap method for adding text deltas inside a child of the target.

But I've just discovered the concept of "out of band" swaps, which allow this! In this PR, with just a few lines of code, we consolidate the SSE listeners for assistant steps and text deltas into a single listener, which sends the assistant steps to the hx-target (before the end of the assistant-run div), but redirects the text deltas to an out-of-band target (an assistant-step div that's a child of the assistant-run).