### PR TITLE
Re-parse accumulated markdown after every streamed text delta

### DIFF
--- a/static/stream-md.js
+++ b/static/stream-md.js
@@ -1,0 +1,98 @@
+// A global map to hold the growing markdown string per target container node
+window._streamingMarkdown = new WeakMap();
+
+function handleSSETextDelta(evt) {
+  // Check if this event is for a 'textDelta' message fired by sse.js
+  const originalSSEEvent = evt.detail;
+  if (!originalSSEEvent || originalSSEEvent.type !== 'textDelta') {
+      return;
+  }
+
+  // Prevent the default HTMX swap for this specific message
+  // sse.js triggers this *before* calling api.swap()
+  evt.preventDefault();
+
+  // The data contains the OOB swap HTML: <span hx-swap-oob="beforeend:#step-...">CHUNK</span>
+  const oobHTML = originalSSEEvent.data;
+
+  // Use DOMParser to safely extract the target selector and the markdown chunk
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(oobHTML, 'text/html');
+  const oobElement = doc.body.firstChild;
+
+  if (!oobElement || !oobElement.getAttribute || oobElement.nodeType !== Node.ELEMENT_NODE) {
+      console.error("Could not parse OOB element from SSE data:", oobHTML);
+      return;
+  }
+
+  const swapOobAttr = oobElement.getAttribute('hx-swap-oob');
+  const markdownChunk = oobElement.textContent || '';
+
+  if (!swapOobAttr) {
+       // Might be a non-OOB textDelta, handle differently or ignore?
+       // For now, let's assume textDelta is always OOB for steps.
+      console.warn("textDelta message did not contain hx-swap-oob:", oobHTML);
+      return;
+  }
+   if (!markdownChunk) {
+      // Empty chunk, nothing to render
+      return;
+  }
+
+  // Extract the target selector (e.g., "beforeend:#step-...") -> "#step-..."
+  let targetSelector = swapOobAttr;
+  const colonIndex = swapOobAttr.indexOf(':');
+  if (colonIndex !== -1) {
+      targetSelector = swapOobAttr.substring(colonIndex + 1);
+  }
+
+  // Find the actual target element where content should be rendered
+  const targetElement = document.querySelector(targetSelector);
+  if (!targetElement) {
+      console.warn("Target element for OOB swap not found:", targetSelector);
+      return;
+  }
+
+  // Use a WeakMap keyed by the *actual target* element
+  if (!window._streamingMarkdown) {
+      window._streamingMarkdown = new WeakMap();
+  }
+
+  // 1) Accumulate markdown for the specific target
+  const prev = window._streamingMarkdown.get(targetElement) || '';
+  const updatedMarkdown = prev + markdownChunk;
+  window._streamingMarkdown.set(targetElement, updatedMarkdown);
+
+  // 2) Re-render -> sanitize -> swap into the target
+  if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+      console.error("marked.js or DOMPurify not loaded.");
+      // Fallback to raw text
+      targetElement.textContent += markdownChunk;
+      return;
+  }
+
+  try {
+      // Use marked.parse() for incremental updates.
+      const rawHtml = marked.parse(updatedMarkdown);
+      // Configure DOMPurify
+      const sanitizedHtml = DOMPurify.sanitize(rawHtml, {
+          // Allows standard HTML elements
+          USE_PROFILES: { html: true }
+       });
+      targetElement.innerHTML = sanitizedHtml;
+
+      // 3) Auto-scroll the main messages container
+      const messagesContainer = document.getElementById('messages');
+      if (messagesContainer) {
+          // Scroll only if the user isn't intentionally scrolled up
+          const isScrolledToBottom = messagesContainer.scrollHeight - messagesContainer.clientHeight <= messagesContainer.scrollTop + 1; // +1 for tolerance
+          if(isScrolledToBottom) {
+              messagesContainer.scrollTop = messagesContainer.scrollHeight;
+          }
+      }
+  } catch (e) {
+      console.error("Error processing markdown:", e);
+      // Fallback on error: append raw chunk to existing text content
+       targetElement.textContent = (targetElement.textContent || '') + markdownChunk;
+  }
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -32,6 +32,15 @@ a {
 ul,
 ol {
   padding-left: 20px;
+  white-space: normal;
+}
+
+li {
+  white-space: normal;
+}
+
+li > ul {
+  margin-bottom: 0;
 }
 
 pre {

--- a/templates/components/assistant-run.html
+++ b/templates/components/assistant-run.html
@@ -3,6 +3,7 @@
      hx-ext="sse"     
      sse-connect="/assistants/{{ assistant_id }}/messages/{{ thread_id }}/receive" 
      sse-swap="messageCreated,toolCallCreated,toolOutput,imageOutput,fileOutput,textDelta" 
+     hx-on:htmx:sse-before-message="handleSSETextDelta(event)"
      sse-close="endStream"
      data-assistant-id="{{ assistant_id }}"
      data-thread-id="{{ thread_id }}">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,8 +8,6 @@
     <link rel="icon" href="{{ url_for('static', path='openai.svg') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}">
     <link rel="favicon" href="{{ url_for('static', path='favicon.png') }}">
-    <script src="{{ url_for('static', path='htmx.min.js') }}"></script>
-    <script src="{{ url_for('static', path='sse.js') }}"></script>
   </head>
   <body>
     <nav class="nav">
@@ -30,5 +28,110 @@
         {% endblock %}
       </div>
     </main>
+    <script src="{{ url_for('static', path='htmx.min.js') }}"></script>
+    <script src="{{ url_for('static', path='sse.js') }}"></script>
+    <!-- Markdown Rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script>
+      // A global map to hold the growing markdown string per target container node
+      window._streamingMarkdown = new WeakMap();
+
+      function handleSSETextDelta(evt) {
+        // Check if this event is for a 'textDelta' message fired by sse.js
+        const originalSSEEvent = evt.detail;
+        if (!originalSSEEvent || originalSSEEvent.type !== 'textDelta') {
+            return;
+        }
+
+        // Prevent the default HTMX swap for this specific message
+        // sse.js triggers this *before* calling api.swap()
+        evt.preventDefault();
+
+        // The data contains the OOB swap HTML: <span hx-swap-oob="beforeend:#step-...">CHUNK</span>
+        const oobHTML = originalSSEEvent.data;
+
+        // Use DOMParser to safely extract the target selector and the markdown chunk
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(oobHTML, 'text/html');
+        const oobElement = doc.body.firstChild;
+
+        if (!oobElement || !oobElement.getAttribute || oobElement.nodeType !== Node.ELEMENT_NODE) {
+            console.error("Could not parse OOB element from SSE data:", oobHTML);
+            return;
+        }
+
+        const swapOobAttr = oobElement.getAttribute('hx-swap-oob');
+        const markdownChunk = oobElement.textContent || '';
+
+        if (!swapOobAttr) {
+             // Might be a non-OOB textDelta, handle differently or ignore?
+             // For now, let's assume textDelta is always OOB for steps.
+            console.warn("textDelta message did not contain hx-swap-oob:", oobHTML);
+            return;
+        }
+         if (!markdownChunk) {
+            // Empty chunk, nothing to render
+            return;
+        }
+
+        // Extract the target selector (e.g., "beforeend:#step-...") -> "#step-..."
+        let targetSelector = swapOobAttr;
+        const colonIndex = swapOobAttr.indexOf(':');
+        if (colonIndex !== -1) {
+            targetSelector = swapOobAttr.substring(colonIndex + 1);
+        }
+
+        // Find the actual target element where content should be rendered
+        const targetElement = document.querySelector(targetSelector);
+        if (!targetElement) {
+            console.warn("Target element for OOB swap not found:", targetSelector);
+            return;
+        }
+
+        // Use a WeakMap keyed by the *actual target* element
+        if (!window._streamingMarkdown) {
+            window._streamingMarkdown = new WeakMap();
+        }
+
+        // 1) Accumulate markdown for the specific target
+        const prev = window._streamingMarkdown.get(targetElement) || '';
+        const updatedMarkdown = prev + markdownChunk;
+        window._streamingMarkdown.set(targetElement, updatedMarkdown);
+
+        // 2) Re-render -> sanitize -> swap into the target
+        if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+            console.error("marked.js or DOMPurify not loaded.");
+            // Fallback to raw text
+            targetElement.textContent += markdownChunk;
+            return;
+        }
+
+        try {
+            // Use marked.parse() for incremental updates.
+            const rawHtml = marked.parse(updatedMarkdown);
+            // Configure DOMPurify
+            const sanitizedHtml = DOMPurify.sanitize(rawHtml, {
+                // Allows standard HTML elements
+                USE_PROFILES: { html: true }
+             });
+            targetElement.innerHTML = sanitizedHtml;
+
+            // 3) Auto-scroll the main messages container
+            const messagesContainer = document.getElementById('messages');
+            if (messagesContainer) {
+                // Scroll only if the user isn't intentionally scrolled up
+                const isScrolledToBottom = messagesContainer.scrollHeight - messagesContainer.clientHeight <= messagesContainer.scrollTop + 1; // +1 for tolerance
+                if(isScrolledToBottom) {
+                    messagesContainer.scrollTop = messagesContainer.scrollHeight;
+                }
+            }
+        } catch (e) {
+            console.error("Error processing markdown:", e);
+            // Fallback on error: append raw chunk to existing text content
+             targetElement.textContent = (targetElement.textContent || '') + markdownChunk;
+        }
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
To pull this off required about a hundred lines of custom Javascript plus the use of a couple extra Javascript dependencies, so it gets a bit away from the purity of our Python + HTMX tech stack. But I did mount the Javascript handler with hx-on, so it's integrated directly with HTMX, using the intended HTMX design pattern, and it should get triggered synchronously during HTMX's processing of the text deltas. (Perhaps a more Platonic solution would involve some pre-processing on the server and/or swapping text deltas into the nested tags created by the markdown parser, but that's well outside the scope of this project!)