### PR TITLE
Convert file citation text deltas to download links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 .repomix-output.txt
 repomix-output.txt
 artifacts/
+uploads/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-assistants-python-quickstart"
-version = "0.1.0"
+version = "1.0.0"
 description = "A quickstart template using the OpenAI Assistants API with Python, FastAPI, Jinja2, and HTMX"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -264,7 +264,7 @@ wheels = [
 
 [[package]]
 name = "openai-assistants-python-quickstart"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Since you can't download files directly from OpenAI, serving assistant files for download necessitates storing the files separately, e.g. locally or on a cloud file server. For purposes of this template, we store them locally in an uploads folder and serve them for download from that folder. To wit:

- The upload and delete file routes now save to and delete from local storage as well as upload to and delete from the OpenAI vector store
- The file storage and retrieval logic is handled by helper functions in utils/files.py that should be relatively easy to customize to work with your custom storage solution
- File citation text deltas from the Assistants API will now be replaced with download links that point to a new FastAPI route for downloading files from storage

In short: when the assistant uses the file search tool, it returns a citation that we turn into a download link. If the user clicks the link, their browser downloads the PDF. Huzzah!
